### PR TITLE
fix: make devcontainers work again

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,6 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/javascript-node/.devcontainer/base.Dockerfile
-
-# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
-ARG VARIANT="16-bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
+ARG VARIANT=18-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/javascript-node
+// https://github.com/microsoft/vscode-dev-containers/tree/main/containers/javascript-node
 {
 	"name": "Node.js",
 	"build": {
@@ -8,28 +8,32 @@
 		// Append -bullseye or -buster to pin to an OS version.
 		// Use -bullseye variants on local arm64/Apple Silicon.
 		"args": {
-			"VARIANT": "16-bullseye"
+			"VARIANT": "18-bullseye"
 		}
 	},
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"bierner.markdown-footnotes",
-		"bierner.markdown-mermaid",
-		"darkriszty.markdown-table-prettify",
-		"davidanson.vscode-markdownlint",
-		"dbaeumer.vscode-eslint",
-		"eg2.vscode-npm-script",
-		"goessner.mdmath",
-		"mathiassoeholm.markdown-link-updater",
-		"matklad.rust-analyzer",
-		"mutantdino.resourcemonitor",
-		"serayuzgur.crates",
-		"tamasfe.even-better-toml",
-		"vadimcn.vscode-lldb",
-		"yzhang.markdown-all-in-one",
-	],
+	"customizations": {
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"bierner.markdown-footnotes",
+				"bierner.markdown-mermaid",
+				"darkriszty.markdown-table-prettify",
+				"davidanson.vscode-markdownlint",
+				"dbaeumer.vscode-eslint",
+				"eg2.vscode-npm-script",
+				"goessner.mdmath",
+				"mathiassoeholm.markdown-link-updater",
+				"matklad.rust-analyzer",
+				"mutantdino.resourcemonitor",
+				"serayuzgur.crates",
+				"tamasfe.even-better-toml",
+				"vadimcn.vscode-lldb",
+				"yzhang.markdown-all-in-one"
+			]
+		}
+	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.


### PR DESCRIPTION
 - upgrade container Node.js version from `16-bullseye` to `18-bullseye`
 - use `main` branch instead of `version` branch when linking to microsoft/vscode-dev-containers repository
 - move VSCode-specific settings to `customizations.vscode` key, per `devcontainer.json` schema update